### PR TITLE
Removed async button action

### DIFF
--- a/UIComponents/Sources/Components/Buttons/ButtonViewModel.swift
+++ b/UIComponents/Sources/Components/Buttons/ButtonViewModel.swift
@@ -3,7 +3,7 @@ import Foundation
 extension GOVUKButton {
     public struct ButtonViewModel {
         public let localisedTitle: String
-        public let action: () async throws -> Void
+        public let action: () -> Void
 
         public init(localisedTitle: String,
                     action: @escaping () -> Void) {

--- a/UIComponents/Sources/Components/Buttons/GOVUKButton.swift
+++ b/UIComponents/Sources/Components/Buttons/GOVUKButton.swift
@@ -50,18 +50,10 @@ final public class GOVUKButton: UIButton {
         configureBackgroundColor()
     }
 
-    private func addNewAction(_ action: @escaping () async throws -> Void) {
-        // future ticket - add loading state handling
+    private func addNewAction(_ action: @escaping () -> Void) {
         let action = UIAction(
             handler: { _ in
-                Task {
-                    do {
-                        try await action()
-                    } catch {
-                        // handle errors
-                    }
-                    // stop loading state
-                }
+                action()
             }
         )
         addAction(action, for: .touchUpInside)


### PR DESCRIPTION
Removed async throws from button action.
Button action was causing crash in TestFlight due to not call action on main thread without any warning before release.

Removing until requirement for loading states in the button where we can decide on final implementation