### PR TITLE
GOVUKAPP-2161 Button focus colour

### DIFF
--- a/UIComponents/Sources/Components/Buttons/GOVUKButton.swift
+++ b/UIComponents/Sources/Components/Buttons/GOVUKButton.swift
@@ -89,10 +89,11 @@ final public class GOVUKButton: UIButton {
 
     public override func accessibilityElementDidLoseFocus() {
         super.accessibilityElementDidLoseFocus()
-        setTitleColor(buttonConfiguration.titleColorNormal, for: .normal)
-        configureBackgroundColor(state: .normal)
-        configureBorderColor(state: .normal)
-        configureShadow(state: .normal)
+        let state: UIControl.State = self.isEnabled ? .normal : .disabled
+        setTitleColor(buttonConfiguration.titleColorNormal, for: state)
+        configureBackgroundColor(state: state)
+        configureBorderColor(state: state)
+        configureShadow(state: state)
     }
 
     public override func accessibilityElementDidBecomeFocused() {


### PR DESCRIPTION
Set the button UI state depending on wether button is enabled or not after losing accessibility focus

[Jira link](https://govukverify.atlassian.net/browse/GOVUKAPP-2161)

Video of fix:
https://github.com/user-attachments/assets/598736c0-2e8b-428b-9d11-ddb3845eab8a